### PR TITLE
[MJS-5] - new route to move tickets from boards

### DIFF
--- a/src/routes/ticketRouter.js
+++ b/src/routes/ticketRouter.js
@@ -63,6 +63,23 @@ router.post("/delete/:id", async (req, res) => {
   }
 });
 
+router.post("/update/", async (req, res) => {
+  console.log("++++++++++++++update post++++++++++++++++");
+  try {
+    const id = req.body.id;
+    const boardId = req.body.boardId;
+    const data = await allTickets.findOneAndUpdate(
+      { Id: id },
+      { boardId: boardId },
+      { returnOriginal: false }
+    );
+
+    res.send(`Document with ${data} has been updated..`);
+  } catch (error) {
+    res.status(400).json({ message: error.message });
+  }
+});
+
 ///////middle ware//////
 // I forgot how this works exactly
 async function getTicket(req, res, next) {


### PR DESCRIPTION
# Description 
add new API endpoint "/update" this endpoint updates the the board-Id of the ticket when they are either moved left or right
#5 

## Caveat 
might have to update the end point to make it "/update/move-ticket/" since the "update/" will mostly be used to update the details of the ticket